### PR TITLE
Desarrollar la funcionalidad que permite ver si un cliente es VIP o no

### DIFF
--- a/app/src/main/java/edu/iesam/pmdm_mayo/app/data/local/db/ExamenDataBase.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/app/data/local/db/ExamenDataBase.kt
@@ -10,7 +10,7 @@ import edu.iesam.pmdm_mayo.features.sales.data.local.db.SalesDao
 
 @Database(
     entities = [ClientEntity::class, SaleEntity::class],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 abstract class ExamenDataBase: RoomDatabase() {

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/client/data/local/ClientEntity.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/client/data/local/ClientEntity.kt
@@ -9,7 +9,7 @@ const val TABLE_NAME = "Clients"
 @Entity(tableName = TABLE_NAME)
 data class ClientEntity (
 
-    @PrimaryKey @ColumnInfo(name = "dni") val dni: Int,
+    @PrimaryKey @ColumnInfo(name = "dni") val dni: String,
     @ColumnInfo(name = "name") val name: String,
     @ColumnInfo(name = "email") val email: String
 )

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/client/data/mock/ClientMockDataSource.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/client/data/mock/ClientMockDataSource.kt
@@ -7,16 +7,16 @@ import org.koin.core.annotation.Single
 class ClientMockDataSource{
     fun getAllClients(): List<Client> {
         return listOf(
-            Client(dni = 12345678, name = "Laura Fernández", email = "laura.fernandez@email.com"),
-            Client(dni = 23456789, name = "Carlos Ruiz", email = "carlos.ruiz@email.com"),
-            Client(dni = 34567890, name = "Marta López", email = "marta.lopez@email.com"),
-            Client(dni = 45678901, name = "Sergio Gómez", email = "sergio.gomez@email.com"),
-            Client(dni = 56789012, name = "Ana Martínez", email = "ana.martinez@email.com"),
-            Client(dni = 67890123, name = "Iván Sánchez", email = "ivan.sanchez@email.com"),
-            Client(dni = 78901234, name = "Lucía Torres", email = "lucia.torres@email.com"),
-            Client(dni = 89012345, name = "David Romero", email = "david.romero@email.com"),
-            Client(dni = 90123456, name = "Elena Navarro", email = "elena.navarro@email.com"),
-            Client(dni = 11223344, name = "Raúl Ortega", email = "raul.ortega@email.com")
+            Client(dni = "12345678", name = "Laura Fernández", email = "laura.fernandez@email.com"),
+            Client(dni = "23456789", name = "Carlos Ruiz", email = "carlos.ruiz@email.com"),
+            Client(dni = "34567890", name = "Marta López", email = "marta.lopez@email.com"),
+            Client(dni = "45678901", name = "Sergio Gómez", email = "sergio.gomez@email.com"),
+            Client(dni = "56789012", name = "Ana Martínez", email = "ana.martinez@email.com"),
+            Client(dni = "67890123", name = "Iván Sánchez", email = "ivan.sanchez@email.com"),
+            Client(dni = "78901234", name = "Lucía Torres", email = "lucia.torres@email.com"),
+            Client(dni = "89012345", name = "David Romero", email = "david.romero@email.com"),
+            Client(dni = "90123456", name = "Elena Navarro", email = "elena.navarro@email.com"),
+            Client(dni = "11223344", name = "Raúl Ortega", email = "raul.ortega@email.com")
         )
     }
 }

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/client/domain/Client.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/client/domain/Client.kt
@@ -2,7 +2,7 @@ package edu.iesam.pmdm_mayo.features.client.domain
 
 
 data class Client (
-    val dni: Int,
+    val dni: String,
     val name: String,
     val email: String
 )

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/client/domain/GetClientsUseCase.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/client/domain/GetClientsUseCase.kt
@@ -1,10 +1,25 @@
 package edu.iesam.pmdm_mayo.features.client.domain
 
+import android.util.Log
+import edu.iesam.pmdm_mayo.features.sales.model.SalesRepository
 import org.koin.core.annotation.Single
 
 @Single
-class GetClientsUseCase(private val repository: ClientRepository) {
-    suspend operator fun invoke(): List<Client>{
-        return repository.getClients()
+class GetClientsUseCase(
+    private val clientRepository: ClientRepository,
+    private val salesRepository: SalesRepository
+) {
+    suspend operator fun invoke(): List<ClientFeed> {
+        val clients = clientRepository.getClients()
+        return clients.map { client ->
+            val sales = salesRepository.getSalesByClient(client.dni)
+            val isVip = sales.size >= 5
+            ClientFeed(client, isVip)
+        }
     }
+
+    data class ClientFeed(
+        val client: Client,
+        val isVip: Boolean
+    )
 }

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/client/presentation/AddClientFragment.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/client/presentation/AddClientFragment.kt
@@ -34,7 +34,7 @@ class AddClientFragment : Fragment() {
     private fun setupViews() {
         binding.btnSave.setOnClickListener {
             val client = Client(
-                dni = binding.inputDni.text.toString().toInt(),
+                dni = binding.inputDni.text.toString(),
                 name = binding.inputName.text.toString(),
                 email = binding.inputEmail.text.toString()
             )

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/client/presentation/ClientAdapter.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/client/presentation/ClientAdapter.kt
@@ -5,8 +5,9 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import edu.iesam.pmdm_mayo.R
 import edu.iesam.pmdm_mayo.features.client.domain.Client
+import edu.iesam.pmdm_mayo.features.client.domain.GetClientsUseCase
 
-class ClientAdapter : ListAdapter<Client, ClientViewHolder>(ClientDiffUtil()) {
+class ClientAdapter : ListAdapter<GetClientsUseCase.ClientFeed, ClientViewHolder>(ClientDiffUtil()) {
 
     private var onDeleteClick: ((Client) -> Unit)? = null
 
@@ -26,4 +27,5 @@ class ClientAdapter : ListAdapter<Client, ClientViewHolder>(ClientDiffUtil()) {
     fun setOnDeleteClickListener(listener: (Client) -> Unit) {
         onDeleteClick = listener
     }
+
 }

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/client/presentation/ClientDiffUtil.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/client/presentation/ClientDiffUtil.kt
@@ -3,13 +3,21 @@ package edu.iesam.pmdm_mayo.features.client.presentation
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.ItemCallback
 import edu.iesam.pmdm_mayo.features.client.domain.Client
+import edu.iesam.pmdm_mayo.features.client.domain.GetClientsUseCase
 
-class ClientDiffUtil: DiffUtil.ItemCallback<Client>() {
-    override fun areItemsTheSame(oldItem: Client, newItem: Client): Boolean {
-        return oldItem.dni == newItem.dni
+class ClientDiffUtil: DiffUtil.ItemCallback<GetClientsUseCase.ClientFeed>() {
+    override fun areItemsTheSame(
+        oldItem: GetClientsUseCase.ClientFeed,
+        newItem: GetClientsUseCase.ClientFeed
+    ): Boolean {
+        return oldItem.client.dni == newItem.client.dni
     }
 
-    override fun areContentsTheSame(oldItem: Client, newItem: Client): Boolean {
+    override fun areContentsTheSame(
+        oldItem: GetClientsUseCase.ClientFeed,
+        newItem: GetClientsUseCase.ClientFeed
+    ): Boolean {
         return oldItem == newItem
     }
+
 }

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/client/presentation/ClientViewHolder.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/client/presentation/ClientViewHolder.kt
@@ -1,24 +1,29 @@
 package edu.iesam.pmdm_mayo.features.client.presentation
 
+import android.util.Log
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import edu.iesam.pmdm_mayo.databinding.ViewClientsItemBinding
 import edu.iesam.pmdm_mayo.features.client.domain.Client
+import edu.iesam.pmdm_mayo.features.client.domain.GetClientsUseCase
 
 
 class ClientViewHolder(private val view: View): ViewHolder(view) {
 
     private val binding = ViewClientsItemBinding.bind(view)
 
-    fun bind(client: Client, onDeleteClick: ((Client)) -> Unit){
-        binding.apply{
-            txtName.text = client.name
-            txtDni.text = client.dni.toString()
-            txtEmail.text = client.email
-
-            binding.btnDelete.setOnClickListener { onDeleteClick.invoke(client) }
-
+    fun bind(client: GetClientsUseCase.ClientFeed, onDeleteClick: ((Client)) -> Unit) {
+        binding.apply {
+            txtName.text = client.client.name
+            txtDni.text = client.client.dni
+            txtEmail.text = client.client.email
+            Log.d("VIP_VIEW", "DNI: ${client.client.dni} | isVip: ${client.isVip}")
+            if (client.isVip) {
+                binding.imgVip.visibility = View.VISIBLE
+            } else {
+                binding.imgVip.visibility = View.GONE
+            }
+            binding.btnDelete.setOnClickListener { onDeleteClick.invoke(client.client) }
         }
     }
-
 }

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/client/presentation/ClientViewModel.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/client/presentation/ClientViewModel.kt
@@ -52,6 +52,6 @@ class ClientViewModel(
     data class UiState(
         val isLoading: Boolean = false,
         val errorApp: Boolean = false,
-        val client: List<Client> = emptyList()
+        val client: List<GetClientsUseCase.ClientFeed> = emptyList()
     )
 }

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/data/SalesDataRepository.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/data/SalesDataRepository.kt
@@ -18,4 +18,8 @@ class SaleDataRepository(
     override suspend fun saveSale(sale: Sales) {
         localDataSource.saveSale(sale)
     }
+
+    override suspend fun getSalesByClient(dni: String): List<Sales> {
+        return localDataSource.getSalesByClient(dni)
+    }
 }

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/data/local/db/SaleEntity.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/data/local/db/SaleEntity.kt
@@ -4,9 +4,9 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-const val TABLE_NAME = "sales"
+const val TABLE_SALES = "sales"
 
-@Entity(tableName = TABLE_NAME)
+@Entity(tableName = TABLE_SALES)
 data class SaleEntity(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
     @ColumnInfo(name= "dni" ) val dni: String,

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/data/local/db/SalesDao.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/data/local/db/SalesDao.kt
@@ -2,11 +2,14 @@ package edu.iesam.pmdm_mayo.features.sales.data.local.db
 
 import androidx.room.Dao
 import androidx.room.Insert
-import androidx.room.OnConflictStrategy
+import androidx.room.Query
 
 @Dao
 interface SalesDao {
 
     @Insert
-    fun save(sale: SaleEntity)
+    suspend fun save(sale: SaleEntity)
+
+    @Query("SELECT * FROM $TABLE_SALES WHERE dni = :dni")
+    suspend fun findByClient(dni: String): List<SaleEntity>
 }

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/data/local/db/SalesDbLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/data/local/db/SalesDbLocalDataSource.kt
@@ -14,6 +14,11 @@ class SaleDbLocalDataSource(
     }
 
     suspend fun getClientDnis(): List<String> {
-        return clientDao.findAll().map { it.dni.toString() }
+        return clientDao.findAll().map { it.dni }
     }
+
+    suspend fun getSalesByClient(dni: String): List<Sales>{
+        return saleDao.findByClient(dni).map { it.toDomain() }
+    }
+
 }

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/model/SalesRepository.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/model/SalesRepository.kt
@@ -3,4 +3,5 @@ package edu.iesam.pmdm_mayo.features.sales.model
 interface SalesRepository {
     suspend fun getClientDni(): List<String>
     suspend fun saveSale(sale: Sales)
+    suspend fun getSalesByClient(dni: String): List<Sales>
 }

--- a/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/presentation/AddSalesFragment.kt
+++ b/app/src/main/java/edu/iesam/pmdm_mayo/features/sales/presentation/AddSalesFragment.kt
@@ -1,6 +1,7 @@
 package edu.iesam.pmdm_mayo.features.sales.presentation
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/res/drawable/ic_vip.xml
+++ b/app/src/main/res/drawable/ic_vip.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M3,13v7h18v-1.5l-9,-7L8,17L3,13zM3,7l4,3l5,-7l5,4h4v8.97l-9.4,-7.31l-3.98,5.48L3,10.44V7z"/>
+    
+</vector>

--- a/app/src/main/res/layout/view_clients_item.xml
+++ b/app/src/main/res/layout/view_clients_item.xml
@@ -51,4 +51,15 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
+    <ImageView
+        android:id="@+id/imgVip"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/ic_vip"
+        android:contentDescription="@string/vip"
+        android:layout_marginStart="8dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/btnDelete"
+        app:layout_constraintBottom_toBottomOf="@id/txtName"
+        android:visibility="gone" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="sales">Concepto Ventas</string>
     <string name="eur">Total (€)</string>
     <string name="add_sale">Añadir Venta</string>
+    <string name="vip">vip\n</string>
 </resources>


### PR DESCRIPTION
### 📝 Descripción de la funcionalidad implementada
- Se desarrolla la funcionalidad del apartado 4 del examen PMDM mayo 2025 que permite marcar visualmente si un cliente es VIP o no.


### 📦 Capa domain
- GetClientsUseCase: se modifica para consultar cuántas ventas tiene cada cliente a través del repositorio de ventas. Si tiene ≥5, se marca como VIP.
- ClientFeed: nueva clase interna que agrupa un Client con un flag isVip: Boolean.

### 🗃 Capa data

- SalesRepository: se amplía con la función getSalesByClient(dni: String): List<Sales>.

- SalesDao: se añade @Query("SELECT * FROM sales WHERE dni = :dni") para obtener las ventas de un cliente concreto.

### 🎨 Capa presentation
- ClientViewModel: expone una lista de ClientFeed en el estado UiState.
- ClientAdapter y ClientViewHolder: ahora reciben ClientFeed y muestran u ocultan el icono VIP (imgVip) según corresponda.

### 🧠 Lógica de negocio
- El cálculo de si un cliente es VIP se hace exclusivamente en el GetClientsUseCase, sin alterar el modelo Client ni en domain ni en data.

### 🖼 Diseño de vistas
- view_clients_item.xml: se añade un ImageView con @drawable/ic_vip y visibilidad controlada desde el ViewHolder.

### 🔍 Logs de verificación
- Se añade un log por cliente: DNI: 12345678 | isVip: true/false para comprobar que la lógica VIP funciona correctamente.